### PR TITLE
Toggle setting between auto and dry

### DIFF
--- a/vpd.yaml
+++ b/vpd.yaml
@@ -198,10 +198,10 @@ action:
                     target:
                       entity_id: !input topene_switch
 
-      # Normálna zóna
+      # Normálna zóna (len ak je aj VPD v hysteréze)
       - conditions:
           - condition: template
-            value_template: "{{ hum >= hum_low and hum <= hum_high }}"
+            value_template: "{{ hum >= hum_low and hum <= hum_high and vpd >= vpd_low and vpd <= vpd_high }}"
         sequence:
           - service: climate.set_hvac_mode
             target:


### PR DESCRIPTION
Tighten the "normal zone" condition in `vpd.yaml` to prevent rapid toggling between Auto and Dry HVAC modes.

---
<a href="https://cursor.com/background-agent?bcId=bc-867b4e4b-f612-4e54-b1e5-8673fbb02178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-867b4e4b-f612-4e54-b1e5-8673fbb02178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

