### PR TITLE
Configure trigger frequency

### DIFF
--- a/vpd.yaml
+++ b/vpd.yaml
@@ -96,6 +96,17 @@ blueprint:
           step: 1
           unit_of_measurement: "%"
 
+    min_run_interval:
+      name: Minimálny interval spustenia
+      description: Najkratší čas medzi spusteniami (v sekundách)
+      default: 60
+      selector:
+        number:
+          min: 0
+          max: 3600
+          step: 5
+          unit_of_measurement: s
+
 trigger:
   - platform: state
     entity_id: !input vpd_sensor
@@ -110,6 +121,11 @@ condition:
   - condition: state
     entity_id: !input enable_switch
     state: "on"
+  - condition: template
+    value_template: >
+      {% set last = state_attr(this.entity_id, 'last_triggered') %}
+      {% set delta = as_timestamp(now()) - (as_timestamp(last) or 0) %}
+      {{ delta >= (!input min_run_interval) }}
 
 action:
   - variables:


### PR DESCRIPTION
Add a configurable minimum run interval to `vpd.yaml` to prevent excessive triggering.

---
<a href="https://cursor.com/background-agent?bcId=bc-963ab881-72fe-472d-9142-46b5d616f35f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-963ab881-72fe-472d-9142-46b5d616f35f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

